### PR TITLE
micro optimization

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -398,7 +398,7 @@ void Search::Worker::iterative_deepening() {
         }
 
         // Have we found a "mate in x"?
-        if (mainThread && limits.mate && rootMoves[0].score == rootMoves[0].uciScore
+        if (limits.mate && mainThread && rootMoves[0].score == rootMoves[0].uciScore
             && ((rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY
                  && VALUE_MATE - rootMoves[0].score <= 2 * limits.mate)
                 || (rootMoves[0].score != -VALUE_INFINITE


### PR DESCRIPTION
I think with this change the PR is almost completely non-functional for sf master when not run with `go mate x`.

Also sorts out my co-authorship. ;)

Possible (part) of text for PR:

This PR fixes two issues with master for `go mate x`:
- when running `go mate x` in losing positions, master always goes to the maximal depth, arguably against what the UCI protocol demands
- when running `go mate x` in winning positions with multiple threads, master may return non-mate scores from the search (this issue is present in stockfish since at least sf16)

The issues are fixed by (a) also checking if score is `mate -x` and by (b) only letting mainthread stop the search for `go mate x` commands, and by not looking for a best thread but using mainthread as per the default.

@peregrineshahin I will add more diagnostics to comments in this PR.